### PR TITLE
Initdb error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# IDEA dot files
+# We could also do the same for .vscode
+.idea

--- a/postgrestest.go
+++ b/postgrestest.go
@@ -57,8 +57,8 @@ type Server struct {
 // Start relies on a few PostgreSQL bundled binaries, namely "pg_ctl" and "initdb".
 // These binaries are used to initialize and manage local database clusters used
 // in your tests. The location of these binaries should reside somewhere in your
-// PATH or in /usr/lib/postgresql/X/bin. When selecting from the latter, the "X"
-// is the largest major version of PostgreSQL locally available.
+// PATH or in /usr/lib/postgresql/X/bin on Linux. When selecting from the latter,
+//the "X" is the largest major version of PostgreSQL locally available.
 func Start(ctx context.Context) (_ *Server, err error) {
 	// Prepare data directory.
 	dir, err := ioutil.TempDir("", "postgrestest")

--- a/postgrestest.go
+++ b/postgrestest.go
@@ -53,6 +53,12 @@ type Server struct {
 
 // Start starts a PostgreSQL server with an empty database and waits for it to
 // accept connections.
+//
+// Start relies on a few PostgreSQL bundled binaries, namely "pg_ctl" and "initdb".
+// These binaries are used to initialize and manage local database clusters used
+// in your tests. The location of these binaries should reside somewhere in your
+// PATH or in /usr/lib/postgresql/X/bin. When selecting from the latter, the "X"
+// is the largest major version of PostgreSQL locally available.
 func Start(ctx context.Context) (_ *Server, err error) {
 	// Prepare data directory.
 	dir, err := ioutil.TempDir("", "postgrestest")

--- a/postgrestest.go
+++ b/postgrestest.go
@@ -54,11 +54,9 @@ type Server struct {
 // Start starts a PostgreSQL server with an empty database and waits for it to
 // accept connections.
 //
-// Start relies on a few PostgreSQL bundled binaries, namely "pg_ctl" and "initdb".
-// These binaries are used to initialize and manage local database clusters used
-// in your tests. The location of these binaries should reside somewhere in your
-// PATH or in /usr/lib/postgresql/X/bin on Linux. When selecting from the latter,
-//the "X" is the largest major version of PostgreSQL locally available.
+// Start looks for the programs "pg_ctl" and "initdb" in PATH. If these are not
+// found, then Start searches for them in /usr/lib/postgresql/*/bin, preferring
+// the highest version found.
 func Start(ctx context.Context) (_ *Server, err error) {
 	// Prepare data directory.
 	dir, err := ioutil.TempDir("", "postgrestest")

--- a/postgrestest.go
+++ b/postgrestest.go
@@ -221,16 +221,15 @@ func command(name string, args ...string) (*exec.Cmd, error) {
 		name += ".exe"
 	}
 	p, lookErr := exec.LookPath(name)
-	if lookErr == nil {
-		return exec.Command(p, args...), nil
-	}
-	postgresBin.init.Do(findPostgresBin)
-	if postgresBin.dir == "" {
-		return nil, lookErr
-	}
-	p = filepath.Join(postgresBin.dir, name)
-	if _, err := os.Stat(p); err != nil {
-		return nil, lookErr
+	if lookErr != nil {
+		postgresBin.init.Do(findPostgresBin)
+		if postgresBin.dir == "" {
+			return nil, lookErr
+		}
+		p = filepath.Join(postgresBin.dir, name)
+		if _, err := os.Stat(p); err != nil {
+			return nil, fmt.Errorf("%s\n%s", err, lookErr)
+		}
 	}
 	return exec.Command(p, args...), nil
 }


### PR DESCRIPTION
Prior to looking at the source code of this library there was no way of knowing that the psql bin directory was checked for an initdb executable.

I just simply joined the two errors and modified some control flow to make it obvious that "p" being used to exec our command.

I also hope you don't mind me adding the .idea dir to the .gitignore file.

PS. Thank you for creating this lib.