### PR TITLE
listen on UNIX Domain Sockets (UDS) instead of TCP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,4 @@ module zombiezen.com/go/postgrestest
 
 go 1.14
 
-require github.com/lib/pq v1.8.0
+require github.com/lib/pq v1.10.10-0.20241116184759-b7ffbd3b47da

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=
-github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.10.10-0.20241116184759-b7ffbd3b47da h1:b0x2DrMfYi9f0dIn36/xrX3ztyam/fByaN14MO48G7s=
+github.com/lib/pq v1.10.10-0.20241116184759-b7ffbd3b47da/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/postgrestest_test.go
+++ b/postgrestest_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
 	"os/exec"
 	"strings"
 	"testing"
@@ -162,6 +163,20 @@ func BenchmarkDocker(b *testing.B) {
 
 type logger interface {
 	Log(...interface{})
+}
+
+func findUnusedTCPPort() (int, error) {
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{
+		IP: net.IPv4(127, 0, 0, 1),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("find unused tcp port: %w", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	if err := l.Close(); err != nil {
+		return 0, fmt.Errorf("find unused tcp port: %w", err)
+	}
+	return port, nil
 }
 
 func startDocker(l logger, dockerExe string) (db *sql.DB, cleanup func(), _ error) {


### PR DESCRIPTION
This removes any need for passwords, which makes the DSN more stable.

related to issue #3